### PR TITLE
SyncReader next() behavior synced

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+# Build only pushed (merged) master or any pull request. This avoids the
+# pull request to be build twice.
+branches:
+  only:
+    - master
+
 language: rust
 
 rust:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 - Internal refactoring (no breaking changes)
 - Removed unsafe `static mut`
 - Documentation update
-- Fixed the `KeyEvent` `BackTab` vs `Tab` bug on the Windows platform 
+
+## Windows only
+
+- Fixed the `KeyEvent` `BackTab` vs `Tab` bug
+- `SyncReader` `Iterator` implementation returns `None` from the `next` method in case of error 
 
 # Version 0.4.1
 

--- a/src/input/windows.rs
+++ b/src/input/windows.rs
@@ -207,8 +207,9 @@ impl Iterator for SyncReader {
     /// `None` doesn't mean that the iteration is finished. See the
     /// [`SyncReader`](struct.SyncReader.html) documentation for more information.
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO Don't unwrap, consume and return `None` to sync behavior with the UNIX
-        read_single_event().unwrap()
+        // This synces the behaviour with the unix::SyncReader (& documentation) where
+        // None is returned in case of error.
+        read_single_event().unwrap_or(None)
     }
 }
 


### PR DESCRIPTION
* Remove TODO in the `SyncReader::next()` (Windows & `Iterator`)
  * `unwrap()` replaced with `unwrap_or(None)` to synchronize the UNIX & Windows behavior
* Travis CI
  * Build PRs or master branch only