### PR TITLE
Mouse coordinates synchronized with the cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Removed unsafe `static mut`
 - Documentation update
 - Remove all references to the crossterm book
+- Mouse coordinates synchronized with the cursor (breaking)
+  - Upper/left reported as `(0, 0)`
 
 ## Windows only
 

--- a/src/input/unix.rs
+++ b/src/input/unix.rs
@@ -415,9 +415,11 @@ where
             let mut next = || iter.next().unwrap();
 
             let cb = next() as i8 - 32;
-            // (1, 1) are the coords for upper left.
-            let cx = next().saturating_sub(32) as u16;
-            let cy = next().saturating_sub(32) as u16;
+            // See http://www.xfree86.org/current/ctlseqs.html#Mouse%20Tracking
+            // The upper left character position on the terminal is denoted as 1,1.
+            // Subtract 1 to keep it synced with cursor
+            let cx = next().saturating_sub(32) as u16 - 1;
+            let cy = next().saturating_sub(32) as u16 - 1;
 
             InputEvent::Mouse(match cb & 0b11 {
                 0 => {
@@ -455,8 +457,11 @@ where
             let nums = &mut str_buf.split(';');
 
             let cb = nums.next().unwrap().parse::<u16>().unwrap();
-            let cx = nums.next().unwrap().parse::<u16>().unwrap();
-            let cy = nums.next().unwrap().parse::<u16>().unwrap();
+            // See http://www.xfree86.org/current/ctlseqs.html#Mouse%20Tracking
+            // The upper left character position on the terminal is denoted as 1,1.
+            // Subtract 1 to keep it synced with cursor
+            let cx = nums.next().unwrap().parse::<u16>().unwrap() - 1;
+            let cy = nums.next().unwrap().parse::<u16>().unwrap() - 1;
 
             match cb {
                 0..=2 | 64..=65 => {

--- a/src/input/windows.rs
+++ b/src/input/windows.rs
@@ -539,8 +539,9 @@ fn parse_mouse_event_record(event: &MouseEvent) -> Option<crate::MouseEvent> {
     // mimicks the behavior; additionally, in xterm, mouse move is only handled when a
     // mouse button is held down (ie. mouse drag)
 
-    let xpos = event.mouse_position.x + 1;
-    let ypos = event.mouse_position.y + 1;
+    // Windows returns (0, 0) for upper/left
+    let xpos = event.mouse_position.x;
+    let ypos = event.mouse_position.y;
 
     // TODO (@imdaveho): check if linux only provides coords for visible terminal window vs the total buffer
 


### PR DESCRIPTION
Fixes https://github.com/crossterm-rs/crossterm/issues/267

Tested on macOS & Linux. **Not tested on Windows**.