### PR TITLE
Calculate relative y mouse event cursor position

### DIFF
--- a/src/input/windows.rs
+++ b/src/input/windows.rs
@@ -24,7 +24,10 @@ use winapi::um::{
     },
 };
 
-use crossterm_winapi::{ButtonState, Console, ConsoleMode, EventFlags, Handle, InputEventType, KeyEventRecord, MouseEvent, ScreenBuffer};
+use crossterm_winapi::{
+    ButtonState, Console, ConsoleMode, EventFlags, Handle, InputEventType, KeyEventRecord,
+    MouseEvent, ScreenBuffer,
+};
 use lazy_static::lazy_static;
 
 use crate::{input::Input, InputEvent, KeyEvent, MouseButton};
@@ -533,7 +536,11 @@ fn parse_mouse_event_record(event: &MouseEvent) -> Option<crate::MouseEvent> {
     // mimicks the behavior; additionally, in xterm, mouse move is only handled when a
     // mouse button is held down (ie. mouse drag)
 
-    let window_size = ScreenBuffer::current().unwrap().info().unwrap().terminal_window();
+    let window_size = ScreenBuffer::current()
+        .unwrap()
+        .info()
+        .unwrap()
+        .terminal_window();
 
     // Windows returns (0, 0) for upper/left
     let xpos = event.mouse_position.x;

--- a/src/input/windows.rs
+++ b/src/input/windows.rs
@@ -547,7 +547,7 @@ fn parse_mouse_event_record(event: &MouseEvent) -> Option<crate::MouseEvent> {
     let mut ypos = event.mouse_position.y;
 
     // The y position in with a mouse event is not relative to the window but absolute to screen buffer.
-    // This means that when the mouse cursor is at top left it will be x: 0, y: 2295 (e.g. y = number of cells counting from the top of the buffer) instead of relative x: 0, y: 0 to the window.
+    // This means that when the mouse cursor is at top left it will be x: 0, y: 2295 (e.g. y = number of cells counting from the absolute buffer height) instead of relative x: 0, y: 0 to the window.
     ypos = ypos - window_size.top;
 
     // TODO (@imdaveho): check if linux only provides coords for visible terminal window vs the total buffer

--- a/src/input/windows.rs
+++ b/src/input/windows.rs
@@ -536,7 +536,7 @@ fn parse_mouse_event_record(event: &MouseEvent) -> Result<Option<crate::MouseEve
     // mimicks the behavior; additionally, in xterm, mouse move is only handled when a
     // mouse button is held down (ie. mouse drag)
 
-    let window_size = ScreenBuffer::current().unwrap().info()?.terminal_window();
+    let window_size = ScreenBuffer::current()?.info()?.terminal_window();
 
     let xpos = event.mouse_position.x;
     let mut ypos = event.mouse_position.y;

--- a/src/input/windows.rs
+++ b/src/input/windows.rs
@@ -541,8 +541,9 @@ fn parse_mouse_event_record(event: &MouseEvent) -> Result<Option<crate::MouseEve
     let xpos = event.mouse_position.x;
     let mut ypos = event.mouse_position.y;
 
-    // The y position in with a mouse event is not relative to the window but absolute to screen buffer.
-    // This means that when the mouse cursor is at top left it will be x: 0, y: 2295 (e.g. y = number of cells counting from the absolute buffer height) instead of relative x: 0, y: 0 to the window.
+    // The 'y' position of a mouse event is not relative to the window but absolute to screen buffer.
+    // This means that when the mouse cursor is at the top left it will be x: 0, y: 2295 (e.g. y = number of cells counting from the absolute buffer height) instead of relative x: 0, y: 0 to the window.
+
     ypos = ypos - window_size.top;
 
     Ok(match event.event_flags {


### PR DESCRIPTION
Fixes: https://github.com/crossterm-rs/crossterm/issues/278

With patch: 

TOP, LEFT click:

![image](https://user-images.githubusercontent.com/19969910/67160756-5166ba00-f354-11e9-8017-300778777c86.png)


Previously: 

TOP, LEFT click
![image](https://user-images.githubusercontent.com/19969910/67160770-680d1100-f354-11e9-9f1c-f9cba072fd71.png)
